### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Jaisonoh
 maintainer=jaisonoh <jaisonoh@gmail.com>
 sentence=Enables beacon setting and functions for arduino.
 paragraph=
+category=Communication
 url=http://arduinoforbeginners.github.io/
 architectures=avr


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library Beacon Library is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format